### PR TITLE
fix out of range crash

### DIFF
--- a/Sources/SwiftFortuneWheel/Utils/Drawing/TextDrawing.swift
+++ b/Sources/SwiftFortuneWheel/Utils/Drawing/TextDrawing.swift
@@ -244,6 +244,8 @@ extension TextDrawing {
         /// Available text rectangles
         var availableTextRects: [CGRect] = []
         
+        guard maxLinesInSlice >= 1 else { return 0 }
+
         /// Counts max available vertical lines and create for each line a max text rectangle
         for line in 1..<Int(maxLinesInSlice) {
             /// Spacing between lines


### PR DESCRIPTION
I came across this while implementing the Wheel of Fortune in SwiftUI. I don't know what exactly is happening but this fixes my crash and makes the code a bit more safe.