### PR TITLE
Fix issue completion block is not called

### DIFF
--- a/Sources/SwiftFortuneWheel/Utils/Animation/SpinningWheelAnimator.swift
+++ b/Sources/SwiftFortuneWheel/Utils/Animation/SpinningWheelAnimator.swift
@@ -160,7 +160,9 @@ extension SpinningWheelAnimator: CAAnimationDelegate {
         if let completionBlock = self.completionBlock,
            let animId = anim.value(forKey: "animId") as? String, animId == "rotation" {
             completionBlock(flag)
-            self.completionBlock = nil
+            if startedAnimationCount < 1 {
+                self.completionBlock = nil
+            }
         }
         startedAnimationCount -= 1
         if startedAnimationCount < 1 {


### PR DESCRIPTION
Fix issue completion block is not called when user repeatedly presses spin button to call startRotationAnimation multiple times.

- Reason: completion block has been released even though animation count > 1